### PR TITLE
Update shepard machine file for the new modules

### DIFF
--- a/components/homme/cmake/machineFiles/shepard.cmake
+++ b/components/homme/cmake/machineFiles/shepard.cmake
@@ -1,13 +1,10 @@
-# Note: CMAKE_CXX_COMPILER needs to be set to the path of nvcc_wrapper
-# nvcc_wrapper will choose either the Nvidia Cuda compiler or the OpenMP compiler depending on what's being compiled
-
 SET(NETCDF_DIR $ENV{NETCDF_ROOT} CACHE FILEPATH "")
-SET(PNETCDF_DIR $ENV{PNETCDF_ROOT} CACHE FILEPATH "")
-
 SET(NETCDF_Fortran_DIR $ENV{NETCDFF_ROOT} CACHE FILEPATH "")
 SET(NETCDFF_DIR $ENV{NETCDFF_ROOT} CACHE FILEPATH "")
+SET(PNETCDF_DIR $ENV{PNETCDF_ROOT} CACHE FILEPATH "")
 
-SET(NetcdfF_LIBRARY -L$ENV{HOME_PREFIX}/lib -lnetcdff -lhdf5_hl -lhdf5 CACHE LIST "")
+#SET(HDF5_C_LIBRARY_hdf5 -lhdf5_hl -lhdf5 CACHE STRING "")
+SET(NetcdfF_LIBRARY -lnetcdff -lhdf5_hl -lhdf5 CACHE LIST "")
 
 SET(HOMME_FIND_BLASLAPACK TRUE CACHE BOOL "")
 


### PR DESCRIPTION
I've unfortunately not found a better way of dealing with the libraries Homme tries to link to yet, so I had to leave most of the hack in.
The main benefit of this upgrade is that we no longer rely on my self compiled version of netcdf fortran