### PR TITLE
Config: Convert Kokkos_LIBRARIES to a list.

### DIFF
--- a/components/homme/cmake/Trilinos.cmake
+++ b/components/homme/cmake/Trilinos.cmake
@@ -17,7 +17,7 @@ IF(USE_TRILINOS)
     SET(EXECUTION_SPACES -DTPL_ENABLE_MPI=ON
                          -DKokkos_ENABLE_MPI=ON)
   
-    SET(Kokkos_LIBRARIES "kokkosalgorithms kokkoscore kokkoscontainers")
+    SET(Kokkos_LIBRARIES "kokkosalgorithms;kokkoscore;kokkoscontainers")
     SET(Kokkos_TPL_LIBRARIES "dl")
   
     IF(${OPENMP_FOUND})


### PR DESCRIPTION
I was getting
  g++: error: kokkoscore: No such file or directory
  g++: error: kokkoscontainers: No such file or directory
because only the first of the three libs got a -l prepended:
  -lkokkosalgorithms kokkoscore kokkoscontainers
Converting the variable to be a list solves the problem for me. However, I'd
like to discuss this with someone else, as I might just be missing something.