### PR TITLE
ctest: Search cprnc output for string "IDENTICAL" to declare success.

### DIFF
--- a/components/homme/cmake/CprncCxxVsF90.cmake.in
+++ b/components/homme/cmake/CprncCxxVsF90.cmake.in
@@ -1,7 +1,3 @@
-function (prc var)
-  message("${var} ${${var}}")
-endfunction ()
-
 # Run cprnc on each of the output files against the target
 # Note: we mix @ and $ notation, since at configure time we only
 #       resolve @ variables. The remaning ones will be resolve by


### PR DESCRIPTION
Previously, success was declared based on the return code, which is not an
accurate indicator of success. This fixes issue #71.