### PR TITLE
Fix for #81, don't use single hyphen cuda flags as they are treated d…

### DIFF
--- a/components/homme/cmake/SetCompilerFlags.cmake
+++ b/components/homme/cmake/SetCompilerFlags.cmake
@@ -124,7 +124,7 @@ ENDIF ()
 # Handle Cuda.
 find_package(CUDA QUIET)
 if (${CUDA_FOUND})
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -expt-extended-lambda -expt-relaxed-constexpr -DCUDA_BUILD")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --expt-extended-lambda --expt-relaxed-constexpr -DCUDA_BUILD")
 endif ()
 
 ##############################################################################


### PR DESCRIPTION
…ifferently during the link stage.

Specifically, this prevents the linker from looking for xpt-relaxed-constexpr as the entry symbol