### PR TITLE
Make an FP mod to how coef(3) is computed in compute_ppm.

### DIFF
--- a/components/homme/src/preqx_flat/unit_tests/remap.cpp
+++ b/components/homme/src/preqx_flat/unit_tests/remap.cpp
@@ -147,7 +147,7 @@ void compute_ppm(const Real a[NLEVP4],
     // xi=(x-x0)/dx
     coefs[j - 1][0] = 1.5 * a[j + 1] - (al + ar) / 4.0;
     coefs[j - 1][1] = ar - al;
-    coefs[j - 1][2] = -6.0 * a[j + 1] + 3.0 * (al + ar);
+    coefs[j - 1][2] = 3.0 * (-2.0 * a[j + 1] + (al + ar));
 
   }  // end of j loop
 

--- a/components/homme/src/share/vertremap_mod_base.F90
+++ b/components/homme/src/share/vertremap_mod_base.F90
@@ -806,7 +806,7 @@ function compute_ppm( a , dx )    result(coefs)
     !Computed these coefficients from the edge values and cell mean in Maple. Assumes normalized coordinates: xi=(x-x0)/dx
     coefs(0,j) = 1.5 * a(j) - ( al + ar ) / 4.
     coefs(1,j) = ar - al
-    coefs(2,j) = -6. * a(j) + 3. * ( al + ar )
+    coefs(2,j) = 3. * (-2. * a(j) + ( al + ar ))
   enddo
 
   !If we're not using a mirrored boundary condition, then make the two cells bordering the top and bottom


### PR DESCRIPTION
Mod made to both C++ and F90. If a[j+1] == al == ar, I believe this mod makes
coef(3) 0 regardless of FP stuff. Not so with the current line.

No rush on this PR. Just here mostly to track the reason for the two failing unit tests in gcc/nvcc build.