### PR TITLE
Config: Add TIMEOUT to optional cmake variables for test cmake scripts.

### DIFF
--- a/components/homme/cmake/HommeMacros.cmake
+++ b/components/homme/cmake/HommeMacros.cmake
@@ -351,6 +351,7 @@ macro(resetTestVariables)
   SET(OMP_NAMELIST_FILES)
   SET(OMP_NUM_THREADS)
   SET(TRILINOS_XML_FILE)
+  SET(TIMEOUT)
 endmacro(resetTestVariables)
 
 macro(printTestSummary)
@@ -523,6 +524,10 @@ macro(createTest testFile)
 
     # Force cprnc to be built when the individual test is run
     ADD_DEPENDENCIES(${THIS_TEST_INDIV} cprnc)
+
+    if (NOT "${TIMEOUT}" STREQUAL "")
+      set_tests_properties(${THIS_TEST} PROPERTIES TIMEOUT ${TIMEOUT})
+    endif ()
 
     # Now make the Individual targets
     #ADD_CUSTOM_COMMAND(TARGET ${THIS_TEST_INDIV}

--- a/components/homme/test/reg_test/run_tests/prtcA-flat-r0-moist-short-c.cmake
+++ b/components/homme/test/reg_test/run_tests/prtcA-flat-r0-moist-short-c.cmake
@@ -13,3 +13,6 @@ SET(VCOORD_FILES ${HOMME_ROOT}/test/vcoord/cam*-26.ascii)
 SET(NC_OUTPUT_FILES
   jw_baroclinic1.nc
   jw_baroclinic2.nc)
+
+# For GPU testbeds, for now.
+SET(TIMEOUT 60)

--- a/components/homme/test/reg_test/run_tests/prtcB-flat-r0-moist-short-c.cmake
+++ b/components/homme/test/reg_test/run_tests/prtcB-flat-r0-moist-short-c.cmake
@@ -12,3 +12,6 @@ SET(VCOORD_FILES ${HOMME_ROOT}/test/vcoord/acme-72*)
 SET(NC_OUTPUT_FILES
   jw_baroclinic1.nc
   jw_baroclinic2.nc)
+
+# For GPU testbeds, for now.
+SET(TIMEOUT 60)

--- a/components/homme/test/reg_test/run_tests/prtcB-flat-r3-moist-short-c.cmake
+++ b/components/homme/test/reg_test/run_tests/prtcB-flat-r3-moist-short-c.cmake
@@ -12,3 +12,8 @@ SET(VCOORD_FILES ${HOMME_ROOT}/test/vcoord/acme-72*)
 SET(NC_OUTPUT_FILES
   jw_baroclinic1.nc
   jw_baroclinic2.nc)
+
+# For GPU testbeds, for now. This particular TIMEOUT should not be required; the
+# test should pass. But set it until we figure out why it's not. Seems to have
+# something to do with MPI.
+SET(TIMEOUT 60)


### PR DESCRIPTION
If not provided, no timeout is added to a list's properties, consistent with
previous behavior.

If provided, then it's added to just that test's properties.

We'll use this to throttle tests on the GPU testbed as needed, to work around
the MPI_Abort hang.