### PR TITLE
Timeout for baseline runs.

### DIFF
--- a/components/homme/cmake/HommeMacros.cmake
+++ b/components/homme/cmake/HommeMacros.cmake
@@ -273,7 +273,8 @@ macro (setUpTestDir TEST_DIR)
     # The baseline runs don't see TIMEOUT, so use Linux timeout as a workaround.
     set (SH_TIMEOUT_CMD)
     if (TIMEOUT)
-      set(SH_TIMEOUT_CMD "timeout ${TIMEOUT} ")
+      MATH(EXPR SH_TIMEOUT "${TIMEOUT} + 10")
+      set(SH_TIMEOUT_CMD "timeout ${SH_TIMEOUT} ")
       endif ()
     FILE(APPEND ${THIS_TEST_SCRIPT} "TEST_${TEST_INDEX}=\"${SH_TIMEOUT_CMD}${CMAKE_CURRENT_BINARY_DIR}/${EXEC_NAME}/${EXEC_NAME} < ${TEST_DIR}/${fileName}\"\n")
     FILE(APPEND ${THIS_TEST_SCRIPT} "\n") # new line


### PR DESCRIPTION
Since baseline runs aren't mananged by cmake, we need to time them out
differently. Use Linux command 'timeout' to do this.

Proposed fix for #116.