### PR TITLE
Exec view reference

### DIFF
--- a/components/homme/src/share/cxx/Utility.hpp
+++ b/components/homme/src/share/cxx/Utility.hpp
@@ -36,7 +36,8 @@ subview(ViewType<ScalarType * [DIM1][DIM2], MemSpace, MemManagement> v_in,
   assert(v_in.data() != nullptr);
   assert(ie < v_in.extent_int(0));
   assert(ie >= 0);
-  return ViewUnmanaged<ScalarType[DIM1][DIM2], MemSpace>(&v_in(ie, 0, 0));
+  return ViewUnmanaged<ScalarType[DIM1][DIM2], MemSpace>(
+      &v_in.implementation_map().reference(ie, 0, 0));
 }
 
 // Here, usually, DIM1=DIM2=2 (D and DInv)


### PR DESCRIPTION
This uses Kokkos' DataMap reference method to get the pointer for the start of the subview. This prevents Kokkos' execution space check from occurring when creating a subview of an execution space view from the host while compiled with debug mode.
This also adds assert guards since I'm not certain Kokkos' reference method will still check that.
Tested on Ride, bowman