### PR TITLE
Quick fix for testing-utils.sh to prevent failures generating baselines

### DIFF
--- a/components/homme/test/reg_test/run_tests/testing-utils.sh
+++ b/components/homme/test/reg_test/run_tests/testing-utils.sh
@@ -238,7 +238,7 @@ runTestsStd() {
     echo -n "Running test ${subJobName} ... "
     echo ""
     # remove suffix '-run' to refer to output files that mpiexec uses in *run.sh
-    subJobName2=${subJobName::-4}
+    subJobName2=${subJobName%????}
     #echo "${subFile} > $THIS_STDOUT 2> $THIS_STDERR"
     chmod u+x ${subFile}
 


### PR DESCRIPTION
This changes how the last 4 characters of a string are removed to prevent some versions of bash from erroring out.
Tested on shepard