### PR TITLE
[wip] adding a target setup for preqx_flat

### DIFF
--- a/components/homme/src/preqx_flat/CMakeLists.txt
+++ b/components/homme/src/preqx_flat/CMakeLists.txt
@@ -239,3 +239,14 @@ ENDIF ()
 MESSAGE (STATUS " +------------ Ending execution of PREQX_FLAT_SETUP -------------+")
 
 ENDMACRO(PREQX_FLAT_SETUP)
+
+
+preqx_flat_setup(FALSE)
+############################################################################
+# createTestExec(exec_name exec_type NP PLEV USE_PIO USE_ENERGY)
+############################################################################
+#createTestExec(prtcA_flat_c preqx_flat 4 4 26 FALSE FALSE 4 Fortran)
+createTestExec(preqx_flat preqx_flat ${PREQX_NP} ${PREQX_NC} ${PREQX_PLEV} ${PREQX_USE_PIO}  ${PREQX_USE_ENERGY} ${QSIZE_D} Fortran)
+
+
+


### PR DESCRIPTION
I am trying to add a mechanism to create preqx_flat_x exec with custom parameters (size, levels). in homme it is just two more lines at the end of CMakeList in preqx. I tried the same and I am getting a comp. error
```
/ascldap/users/onguba/acmexx/components/homme/src/share/cxx/Types.hpp(4): catastrophic error: cannot open source file "Hommexx_config.h"
  #include <Hommexx_config.h>
                             ^

compilation aborted for /ascldap/users/onguba/acmexx/components/homme/src/share/cxx/cxx_f90_interface.cpp (code 4)
make[3]: *** [src/preqx_flat/CMakeFiles/preqx_flat.dir/__/share/cxx/cxx_f90_interface.cpp.o] Error 4
```
Does anyone know what i am missing? @ambrad @mfdeakin-sandia ?

I am creating an exec with this script:
```
set wdir =  `pwd`             # run directory
set HOMME = ~/acmexx/components/homme                # HOMME svn checkout     
echo $HOMME
set bld = $wdir/bldxx                      # cmake/build directory
set MACH = $HOMME/cmake/machineFiles/skybridge.cmake
set nlev=72
set qsize=40
mkdir -p $bld
cd $bld
set build = 1  # set to 1 to force build
set conf = 1
rm $bld/CMakeCache.txt    # remove this file to force re-configure
if ( $conf ) then
   rm -rf CMakeFiles CMakeCache.txt src
   echo "running CMAKE to configure the model"
   cmake -C $MACH -DQSIZE_D=$qsize -DPREQX_PLEV=$nlev -DPREQX_NP=4  \
   -DPREQX_NC=4 \
   -DPREQX_USE_PIO=FALSE \
   -DBUILD_HOMME_SWEQX=FALSE                     \
   -DUSE_TRILINOS=OFF  \
   -DKOKKOS_PATH=${HOME}/kokkos/build-omp-debug/  \
   -DHOMMEXX_FPMODEL=strict   \
   -DUSE_KOKKOS_KERNELS=TRUE \
   -DHOMME_USE_FLAT_ARRAYS=TRUE  \
   -DPREQX_USE_ENERGY=FALSE  $HOMME

   make -j4 clean
   make -j8 preqx_flat
   exit
endif

```