### PR TITLE
Fix MPI and Kokkos init order.

### DIFF
--- a/components/homme/src/share/cxx/Hommexx_Session.cpp
+++ b/components/homme/src/share/cxx/Hommexx_Session.cpp
@@ -20,19 +20,17 @@ void initialize_hommexx_session ()
    * threads/processors Kokkos uses */
   initialize_kokkos();
 
-  ExecSpace::print_configuration(std::cout, true);
-
-  // Put here other initialization routines (e.g., MPI)
-  if (Context::singleton().get_comm().m_rank == 0)
+  const auto comm = Context::singleton().get_comm();
+  if (comm.root()) {
+    ExecSpace::print_configuration(std::cout, true);
     std::cout << "HOMMEXX SHA1: " << HOMMEXX_SHA1 << "\n";
+  }
 }
 
 void finalize_hommexx_session ()
 {
   Context::finalize_singleton();
   Kokkos::finalize();
-
-  // Put here other finalization routines (e.g., MPI)
 }
 
 } // namespace Homme

--- a/components/homme/src/share/cxx/mpi/Comm.cpp
+++ b/components/homme/src/share/cxx/mpi/Comm.cpp
@@ -59,4 +59,9 @@ void Comm::init ()
 #endif
 }
 
+bool Comm::root () const
+{
+  return m_rank == 0;
+}
+
 } // namespace Homme

--- a/components/homme/src/share/cxx/mpi/Comm.hpp
+++ b/components/homme/src/share/cxx/mpi/Comm.hpp
@@ -27,6 +27,8 @@ struct Comm
   // out what processes are dedicated to Homme, and create a comm
   // involving only those processes.
   void init ();
+
+  bool root () const;
 };
 
 } // namespace Homme

--- a/components/homme/test/unit_tests/tester.cpp
+++ b/components/homme/test/unit_tests/tester.cpp
@@ -10,10 +10,10 @@
 
 int main(int argc, char **argv) {
 
-  Homme::initialize_hommexx_session();
-
   // Initialize mpi
   MPI_Init(&argc,&argv);
+
+  Homme::initialize_hommexx_session();
 
   int result = Catch::Session().run(argc, argv);
 


### PR DESCRIPTION
This fixes the unit test initialization.

Also put the Kokkos config printing inside of a root() check so that only the
root rank prints out Kokkos data. Printing on all ranks doesn't scale.