### PR TITLE
Simplified par scan test

### DIFF
--- a/components/homme/src/share/cxx/utilities/SubviewUtils.hpp
+++ b/components/homme/src/share/cxx/utilities/SubviewUtils.hpp
@@ -54,7 +54,7 @@ subview(ViewType<ScalarType * [DIM1][DIM2], MemSpace, Properties...> v_in,
         int idx_0, const int idx_1) {
   assert(v_in.data() != nullptr);
   assert(idx_0 >= 0 && idx_0 < v_in.extent_int(0) );
-  assert(idx_1 >= 0 && idx_1 < v_in.extent_int(0) );
+  assert(idx_1 >= 0 && idx_1 < v_in.extent_int(1) );
   return ViewUnmanaged<ScalarType[DIM2], MemSpace>(
       &v_in.implementation_map().reference(idx_0, idx_1, 0));
 }


### PR DESCRIPTION
Fixes and reduction of duplicated code. Also use a threshold of 4 epsilon and a scan length of 97.