### PR TITLE
Fix limiter_option = 9.

### DIFF
--- a/components/homme/src/share/cxx/EulerStepFunctor.hpp
+++ b/components/homme/src/share/cxx/EulerStepFunctor.hpp
@@ -26,6 +26,11 @@ public:
 
   void euler_step(const int np1_qdp, const int n0_qdp, const Real dt,
                   const Real rhs_multiplier, const DSSOption DSSopt);
+
+  KOKKOS_INLINE_FUNCTION
+  static bool is_quasi_monotone (const int& limiter_option) {
+    return limiter_option == 8 || limiter_option == 9;
+  }
 };
 
 } // namespace Homme

--- a/components/homme/src/share/cxx/prim_advec_tracers_remap.cpp
+++ b/components/homme/src/share/cxx/prim_advec_tracers_remap.cpp
@@ -75,7 +75,7 @@ void prim_advec_tracers_remap_RK2 (const Real dt)
   Kokkos::fence();
   GPTLstop("tl-at qdp_time_avg");
 
-  if ( ! (params.limiter_option == 8 || params.limiter_option == 9)) {
+  if ( ! EulerStepFunctor::is_quasi_monotone(params.limiter_option)) {
     Errors::option_error("prim_advec_tracers_remap_RK2","limiter_option",
                           params.limiter_option);
     // call advance_hypervis_scalar(edgeadv,elem,hvcoord,hybrid,deriv,tl%np1,np1_qdp,nets,nete,dt)


### PR DESCRIPTION
Steps were being skipped with this limiter. Use new convenience function
EulerStepFunctor::is_quasi_monotone to get away from explicit 8/9 checks.

Running tests now.