### PR TITLE
Macroize the pragmas for the SIMD vector type

### DIFF
--- a/src/share/cxx/EulerStepFunctorImpl.hpp
+++ b/src/share/cxx/EulerStepFunctorImpl.hpp
@@ -21,6 +21,7 @@
 #include "ErrorDefs.hpp"
 #include "BoundaryExchange.hpp"
 #include "profiling.hpp"
+#include "vector/vector_pragmas.hpp"
 
 namespace Kokkos {
 struct Real2 {
@@ -704,8 +705,8 @@ private:
         Kokkos::TeamThreadRange(team, NUM_PHYSICAL_LEV),
         f);
     } else {
-#     pragma ivdep
-#     pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
       for (int ilev = 0; ilev < NUM_PHYSICAL_LEV; ++ilev)
         f(ilev);
     }
@@ -855,8 +856,8 @@ KOKKOS_INLINE_FUNCTION void SerialLimiter<ExecSpace>
   Real mass[NUM_PHYSICAL_LEV] = {0}, sumc[NUM_PHYSICAL_LEV] = {0};
   forij {
     const auto& sphij = sphweights(i,j);
-#   pragma ivdep
-#   pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
     forlev {
       const auto& dpm = dpmass(i,j,lev);
       c(i,j,lev) = sphij*dpm;
@@ -866,8 +867,8 @@ KOKKOS_INLINE_FUNCTION void SerialLimiter<ExecSpace>
     }
   }
 
-# pragma ivdep
-# pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
   forlev {
     if (qlim(0,lev) < 0)
       qlim(0,lev) = 0;
@@ -886,8 +887,8 @@ KOKKOS_INLINE_FUNCTION void SerialLimiter<ExecSpace>
       Real addmass[NUM_PHYSICAL_LEV] = {0};
 
       forij {
-#       pragma ivdep
-#       pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
         forlev {
           auto& xij = x(i,j,lev);
           Real delta = 0;
@@ -913,8 +914,8 @@ KOKKOS_INLINE_FUNCTION void SerialLimiter<ExecSpace>
 
       Real f[NUM_PHYSICAL_LEV] = {0};
       forij {
-#       pragma ivdep
-#       pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
         forlev {
           if (done[lev]) continue;
           if (addmass[lev] <= 0) {
@@ -927,16 +928,16 @@ KOKKOS_INLINE_FUNCTION void SerialLimiter<ExecSpace>
         }
       }
 
-#     pragma ivdep
-#     pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
       forlev {
         if (f[lev] != 0)
           f[lev] = addmass[lev] / f[lev];
       }
 
       forij {
-#       pragma ivdep
-#       pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
         forlev {
           if (done[lev]) continue;
           if (addmass[lev] <= 0) {
@@ -953,8 +954,8 @@ KOKKOS_INLINE_FUNCTION void SerialLimiter<ExecSpace>
     Real addmass[NUM_PHYSICAL_LEV] = {0};
 
     forij {
-#     pragma ivdep
-#     pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
       forlev {
         auto& xij = x(i,j,lev);
         Real delta = 0;
@@ -971,8 +972,8 @@ KOKKOS_INLINE_FUNCTION void SerialLimiter<ExecSpace>
 
     Real f[NUM_PHYSICAL_LEV] = {0};
     forij {
-#     pragma ivdep
-#     pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
       forlev {
         auto& xij = x(i,j,lev);
         if (addmass[lev] <= 0) {
@@ -985,16 +986,16 @@ KOKKOS_INLINE_FUNCTION void SerialLimiter<ExecSpace>
       }
     }
 
-#   pragma ivdep
-#   pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
     forlev {
       if (f[lev] != 0)
         f[lev] = addmass[lev] / f[lev];
     }
 
     forij {
-#     pragma ivdep
-#     pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
       forlev {
         auto& xij = x(i,j,lev);
         if (addmass[lev] <= 0) {
@@ -1011,8 +1012,8 @@ KOKKOS_INLINE_FUNCTION void SerialLimiter<ExecSpace>
   }
 
   forij {
-#   pragma ivdep
-#   pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
     forlev {
       x(i,j,lev) *= dpmass(i,j,lev);
     }

--- a/src/share/cxx/ExecSpaceDefs.hpp
+++ b/src/share/cxx/ExecSpaceDefs.hpp
@@ -13,6 +13,7 @@
 
 #include "Config.hpp"
 #include "Dimensions.hpp"
+#include "vector/vector_pragmas.hpp"
 
 namespace Homme
 {
@@ -273,8 +274,8 @@ struct Dispatch {
     const typename Kokkos::TeamPolicy<ExeSpace>::member_type& team,
     const Lambda& lambda)
   {
-#   pragma ivdep
-#   pragma simd
+VECTOR_IVDEP_LOOP
+VECTOR_SIMD_LOOP
     for (int k = 0; k < NP*NP; ++k)
       lambda(k);
   }

--- a/src/share/cxx/Hommexx_Session.cpp
+++ b/src/share/cxx/Hommexx_Session.cpp
@@ -12,6 +12,8 @@
 #include "Config.hpp"
 #include "mpi/Comm.hpp"
 
+#include "vector/vector_pragmas.hpp"
+
 #include <iostream>
 
 namespace Homme
@@ -38,6 +40,13 @@ void initialize_hommexx_session ()
     std::cout << "HOMMEXX vector tag: " << Scalar::label() << "\n";
     std::cout << "HOMMEXX MPI_ON_DEVICE: " << HOMMEXX_MPI_ON_DEVICE << "\n";
     std::cout << "HOMMEXX CUDA_MIN_WARP_PER_TEAM: " << HOMMEXX_CUDA_MIN_WARP_PER_TEAM << "\n";
+
+#ifndef HOMMEXX_NO_VECTOR_PRAGMAS
+    std::cout << "HOMMEXX has vector pragmas\n";
+#else
+    std::cout << "HOMMEXX doesn't have vector pragmas\n";
+#endif
+
 #ifdef HOMMEXX_CONFIG_IS_CMAKE
     std::cout << "HOMMEXX configured with CMake\n";
 # ifdef HAVE_CONFIG_H

--- a/src/share/cxx/utilities/VectorUtils.hpp
+++ b/src/share/cxx/utilities/VectorUtils.hpp
@@ -7,6 +7,7 @@
 #ifndef HOMMEXX_VECTOR_UTILS_HPP
 #define HOMMEXX_VECTOR_UTILS_HPP
 
+#include "vector/vector_pragmas.hpp"
 #include "vector/KokkosKernels_Vector.hpp"
 #include "utilities/MathUtils.hpp"
 
@@ -57,7 +58,7 @@ max (const Vector<VectorTag<SIMD<double, SpT>, l> >& a,
      const Vector<VectorTag<SIMD<double, SpT>, l> >& b)
 {
   Vector<VectorTag<SIMD<double, SpT>, l> > r_val;
-#pragma ivdep
+VECTOR_SIMD_LOOP
   for (int i = 0; i < Vector<VectorTag<SIMD<double, SpT>, l>>::vector_length; i++) {
     r_val[i] = Homme::max(a[i],b[i]);
   }
@@ -72,7 +73,7 @@ min (const Vector<VectorTag<SIMD<double, SpT>, l> >& a,
      const Vector<VectorTag<SIMD<double, SpT>, l> >& b)
 {
   Vector<VectorTag<SIMD<double, SpT>, l> > r_val;
-#pragma ivdep
+VECTOR_SIMD_LOOP
   for (int i = 0; i < Vector<VectorTag<SIMD<double, SpT>, l>>::vector_length; i++) {
     r_val[i] = Homme::min(a[i],b[i]);
   }

--- a/src/share/cxx/vector/KokkosKernels_Vector_SIMD.hpp
+++ b/src/share/cxx/vector/KokkosKernels_Vector_SIMD.hpp
@@ -45,6 +45,7 @@
 /// \author Kyungjoo Kim (kyukim@sandia.gov)
 
 #include <assert.h>
+#include "vector_pragmas.hpp"
 
 namespace KokkosKernels {
 namespace Batched {
@@ -70,20 +71,20 @@ private:
 
 public:
   KOKKOS_INLINE_FUNCTION Vector() {
-#pragma ivdep
+VECTOR_SIMD_LOOP
     for (int i = 0; i < vector_length; i++) {
       _data[i] = 0;
     }
   }
   template <typename ArgValueType>
   KOKKOS_INLINE_FUNCTION Vector(const ArgValueType val) {
-#pragma ivdep
+VECTOR_SIMD_LOOP
     for (int i = 0; i < vector_length; i++) {
       _data[i] = val;
     }
   }
   KOKKOS_INLINE_FUNCTION Vector(const type &b) {
-#pragma ivdep
+VECTOR_SIMD_LOOP
     for (int i = 0; i < vector_length; i++) {
       _data[i] = b._data[i];
     }
@@ -91,7 +92,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION
   type &loadAligned(value_type const *p) {
-#pragma ivdep
+VECTOR_SIMD_LOOP
     for (int i = 0; i < vector_length; i++) {
       _data[i] = p[i];
     }
@@ -100,7 +101,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION
   type &loadUnaligned(value_type const *p) {
-#pragma ivdep
+VECTOR_SIMD_LOOP
     for (int i = 0; i < vector_length; i++) {
       _data[i] = p[i];
     }
@@ -113,7 +114,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION
   void storeAligned(value_type *p) const {
-#pragma ivdep
+VECTOR_SIMD_LOOP
     for (int i = 0; i < vector_length; i++) {
       p[i] = _data[i];
     }
@@ -121,7 +122,7 @@ public:
 
   KOKKOS_INLINE_FUNCTION
   void storeUnaligned(value_type *p) const {
-#pragma ivdep
+VECTOR_SIMD_LOOP
     for (int i = 0; i < vector_length; i++) {
       p[i] = _data[i];
     }
@@ -167,7 +168,7 @@ KOKKOS_INLINE_FUNCTION static Vector<VectorTag<SIMD<T, SpT>, l> >
 operator+(Vector<VectorTag<SIMD<T, SpT>, l> > const &a,
           Vector<VectorTag<SIMD<T, SpT>, l> > const &b) {
   Vector<VectorTag<SIMD<T, SpT>, l> > r_val;
-#pragma ivdep
+VECTOR_SIMD_LOOP
   for (int i = 0; i < Vector<VectorTag<SIMD<T, SpT>, l> >::vector_length; i++) {
     r_val[i] = a[i] + b[i];
   }
@@ -224,7 +225,7 @@ KOKKOS_INLINE_FUNCTION static Vector<VectorTag<SIMD<T, SpT>, l> >
 operator-(Vector<VectorTag<SIMD<T, SpT>, l> > const &a,
           Vector<VectorTag<SIMD<T, SpT>, l> > const &b) {
   Vector<VectorTag<SIMD<T, SpT>, l> > r_val;
-#pragma ivdep
+VECTOR_SIMD_LOOP
   for (int i = 0; i < Vector<VectorTag<SIMD<T, SpT>, l> >::vector_length; i++) {
     r_val[i] = a[i] - b[i];
   }
@@ -248,7 +249,7 @@ operator-(const typename VectorTag<SIMD<T, SpT>, l>::value_type a,
 template <typename T, typename SpT, int l>
 KOKKOS_INLINE_FUNCTION static Vector<VectorTag<SIMD<T, SpT>, l> >
 operator-(Vector<VectorTag<SIMD<T, SpT>, l> > a) {
-#pragma ivdep
+VECTOR_SIMD_LOOP
   for (int i = 0; i < Vector<VectorTag<SIMD<T, SpT>, l> >::vector_length; i++) {
     a[i] = -a[i];
   }
@@ -291,7 +292,7 @@ KOKKOS_INLINE_FUNCTION static Vector<VectorTag<SIMD<T, SpT>, l> >
 operator*(Vector<VectorTag<SIMD<T, SpT>, l> > const &a,
           Vector<VectorTag<SIMD<T, SpT>, l> > const &b) {
   Vector<VectorTag<SIMD<T, SpT>, l> > r_val;
-#pragma ivdep
+VECTOR_SIMD_LOOP
   for (int i = 0; i < Vector<VectorTag<SIMD<T, SpT>, l> >::vector_length; i++) {
     r_val[i] = a[i] * b[i];
   }
@@ -333,7 +334,7 @@ KOKKOS_INLINE_FUNCTION static Vector<VectorTag<SIMD<T, SpT>, l> >
 operator/(Vector<VectorTag<SIMD<T, SpT>, l> > const &a,
           Vector<VectorTag<SIMD<T, SpT>, l> > const &b) {
   Vector<VectorTag<SIMD<T, SpT>, l> > r_val;
-#pragma ivdep
+VECTOR_SIMD_LOOP
   for (int i = 0; i < Vector<VectorTag<SIMD<T, SpT>, l> >::vector_length; i++) {
     r_val[i] = a[i] / b[i];
   }

--- a/src/share/cxx/vector/vector_pragmas.hpp
+++ b/src/share/cxx/vector/vector_pragmas.hpp
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * HOMMEXX 1.0: Copyright of Sandia Corporation
+ * This software is released under the BSD license
+ * See the file 'COPYRIGHT' in the HOMMEXX/src/share/cxx directory
+ *******************************************************************************/
+
+#ifndef HOMMEXX_VECTOR_PRAGMAS_HPP
+#define HOMMEXX_VECTOR_PRAGMAS_HPP
+
+#if defined(__INTEL_COMPILER)
+
+#define VECTOR_SIMD_LOOP _Pragma("simd")
+#define VECTOR_IVDEP_LOOP _Pragma("ivdep")
+#define ALWAYS_VECTORIZE_LOOP _Pragma("vector always")
+
+#elif defined(__GNUG__) && !defined(__NVCC__)
+#if(__GNUG__ == 4 && __GNUC_MINOR__ >= 9) || __GNUG__ > 4
+
+#define VECTOR_SIMD_LOOP _Pragma("GCC simd")
+#define VECTOR_IVDEP_LOOP _Pragma("GCC ivdep")
+#define ALWAYS_VECTORIZE_LOOP _Pragma("GCC vector always")
+
+#else // __GNUG__ ...
+#pragma message( \
+    "G++ <4.9 Does not support vectorization pragmas")
+#define VECTOR_SIMD_LOOP
+#define VECTOR_IVDEP_LOOP
+#define ALWAYS_VECTORIZE_LOOP
+
+#define HOMMEXX_NO_VECTOR_PRAGMAS
+
+#endif // __GNUG__ ...
+
+#else // defined(__INTEL_COMPILER) / defined(__GNUG__) ...
+// fail gracefully when the compiler vectorization pragmas are unknown
+
+#define VECTOR_SIMD_LOOP
+#define VECTOR_IVDEP_LOOP
+#define ALWAYS_VECTORIZE_LOOP
+
+#define HOMMEXX_NO_VECTOR_PRAGMAS
+
+#endif // defined(__INTEL_COMPILER) / defined(__GNUG__) ...
+
+#endif // HOMMEXX_VECTOR_PRAGMAS_HPP


### PR DESCRIPTION
Not yet tested, but should eliminate unknown pragma warnings for gcc and other compilers