### PR TITLE
Cam mpi support

### DIFF
--- a/src/prim_main.F90
+++ b/src/prim_main.F90
@@ -32,7 +32,7 @@ program prim_main
   use prim_state_mod,   only: prim_printstate
 
 #ifdef USE_KOKKOS_KERNELS
-  use prim_cxx_driver_mod, only: cleanup_cxx_structures
+  use prim_cxx_driver_mod, only: init_cxx_mpi_comm, cleanup_cxx_structures
   use element_mod,         only: elem_state_v, elem_state_temp, elem_state_dp3d, &
                                  elem_state_Qdp, elem_state_Q, elem_state_ps_v,  &
                                  elem_derived_omega_p
@@ -134,6 +134,8 @@ program prim_main
   par=initmp()
 
 #ifdef USE_KOKKOS_KERNELS
+  call init_cxx_mpi_comm(INT(par%comm,c_int))
+
   ! Do this right away, but AFTER MPI initialization
   call initialize_hommexx_session()
 #endif

--- a/src/prim_main.F90
+++ b/src/prim_main.F90
@@ -134,7 +134,7 @@ program prim_main
   par=initmp()
 
 #ifdef USE_KOKKOS_KERNELS
-  call init_cxx_mpi_comm(INT(par%comm,c_int))
+  call init_cxx_mpi_comm(par%comm)
 
   ! Do this right away, but AFTER MPI initialization
   call initialize_hommexx_session()

--- a/src/prim_main.F90
+++ b/src/prim_main.F90
@@ -32,7 +32,7 @@ program prim_main
   use prim_state_mod,   only: prim_printstate
 
 #ifdef USE_KOKKOS_KERNELS
-  use prim_cxx_driver_mod, only: init_cxx_mpi_comm, cleanup_cxx_structures
+  use prim_cxx_driver_mod, only: init_cxx_mpi_comm
   use element_mod,         only: elem_state_v, elem_state_temp, elem_state_dp3d, &
                                  elem_state_Qdp, elem_state_Q, elem_state_ps_v,  &
                                  elem_derived_omega_p
@@ -410,7 +410,6 @@ program prim_main
   if(par%masterproc) print *,"calling t_finalizef"
   call t_finalizef()
 #ifdef USE_KOKKOS_KERNELS
-  call cleanup_cxx_structures ()
   call finalize_hommexx_session()
 #endif
   call haltmp("exiting program...")

--- a/src/share/cxx/Context.cpp
+++ b/src/share/cxx/Context.cpp
@@ -39,7 +39,6 @@ CaarFunctor& Context::get_caar_functor() {
 Comm& Context::get_comm() {
   if ( ! comm_) {
     comm_.reset(new Comm());
-    comm_->init();
   }
   return *comm_;
 }

--- a/src/share/cxx/Context.cpp
+++ b/src/share/cxx/Context.cpp
@@ -44,6 +44,14 @@ Comm& Context::get_comm() {
   return *comm_;
 }
 
+void Context::create_comm(const int f_comm) {
+  // You should NOT create a C MPI_Comm from F90 twice during the same execution
+  assert (!comm_);
+
+  MPI_Comm c_comm = MPI_Comm_f2c(f_comm);
+  comm_.reset(new Comm(c_comm));
+}
+
 Diagnostics& Context::get_diagnostics() {
   if ( ! diagnostics_) diagnostics_.reset(new Diagnostics());
   return *diagnostics_;

--- a/src/share/cxx/Context.hpp
+++ b/src/share/cxx/Context.hpp
@@ -71,6 +71,7 @@ public:
 
   // Getters for each managed object.
   CaarFunctor& get_caar_functor();
+  void create_comm(const int f_comm);
   Comm& get_comm();
   Diagnostics& get_diagnostics();
   Elements& get_elements();

--- a/src/share/cxx/mpi/BoundaryExchange.cpp
+++ b/src/share/cxx/mpi/BoundaryExchange.cpp
@@ -240,7 +240,7 @@ void BoundaryExchange::exchange (const ExecViewUnmanaged<const Real * [NP][NP]>*
   // Hey, if some process can already send me stuff while I'm still packing, that's ok
   if ( ! m_recv_requests.empty())
     HOMMEXX_MPI_CHECK_ERROR(MPI_Startall(m_recv_requests.size(), m_recv_requests.data()),
-                            m_connectivity->get_comm().m_mpi_comm);
+                            m_connectivity->get_comm().mpi_comm());
   m_recv_pending = true;
 
   // ---- Pack and send ---- //
@@ -272,7 +272,7 @@ void BoundaryExchange::exchange_min_max ()
   // Hey, if some process can already send me stuff while I'm still packing, that's ok
   if ( ! m_recv_requests.empty())
     HOMMEXX_MPI_CHECK_ERROR(MPI_Startall(m_recv_requests.size(), m_recv_requests.data()),
-                            m_connectivity->get_comm().m_mpi_comm);
+                            m_connectivity->get_comm().mpi_comm());
   m_recv_pending = true;
 
   // ---- Pack and send ---- //
@@ -415,7 +415,7 @@ void BoundaryExchange::pack_and_send ()
   tstart("be send");
   if ( ! m_send_requests.empty())
     HOMMEXX_MPI_CHECK_ERROR(MPI_Startall(m_send_requests.size(), m_send_requests.data()),
-                            m_connectivity->get_comm().m_mpi_comm);
+                            m_connectivity->get_comm().mpi_comm());
 
   // Notify a send is ongoing
   m_send_pending = true;
@@ -453,7 +453,7 @@ void BoundaryExchange::recv_and_unpack (const ExecViewUnmanaged<const Real * [NP
 
     if ( ! m_recv_requests.empty())
       HOMMEXX_MPI_CHECK_ERROR(MPI_Startall(m_recv_requests.size(), m_recv_requests.data()),
-                              m_connectivity->get_comm().m_mpi_comm);
+                              m_connectivity->get_comm().mpi_comm());
     m_recv_pending = true;
   }
   tstop("be recv_and_unpack book");
@@ -462,7 +462,7 @@ void BoundaryExchange::recv_and_unpack (const ExecViewUnmanaged<const Real * [NP
   tstart("be recv waitall");
   if ( ! m_recv_requests.empty())
     HOMMEXX_MPI_CHECK_ERROR(MPI_Waitall(m_recv_requests.size(), m_recv_requests.data(), MPI_STATUSES_IGNORE),
-                            m_connectivity->get_comm().m_mpi_comm); // Wait for all data to arrive
+                            m_connectivity->get_comm().mpi_comm()); // Wait for all data to arrive
   m_recv_pending = false;
   tstop("be recv waitall");
 
@@ -605,7 +605,7 @@ void BoundaryExchange::recv_and_unpack (const ExecViewUnmanaged<const Real * [NP
   if ( ! m_send_requests.empty())
     HOMMEXX_MPI_CHECK_ERROR(MPI_Waitall(m_send_requests.size(), m_send_requests.data(),
                                         MPI_STATUSES_IGNORE),
-                            m_connectivity->get_comm().m_mpi_comm); // Wait for all data to arrive
+                            m_connectivity->get_comm().mpi_comm()); // Wait for all data to arrive
   tstop("be waitall 2");
 
   tstart("be recv_and_unpack book");
@@ -720,7 +720,7 @@ void BoundaryExchange::pack_and_send_min_max ()
   m_buffers_manager->sync_send_buffer(this);
   if ( ! m_send_requests.empty())
     HOMMEXX_MPI_CHECK_ERROR(MPI_Startall(m_send_requests.size(), m_send_requests.data()),
-                            m_connectivity->get_comm().m_mpi_comm);
+                            m_connectivity->get_comm().mpi_comm());
 
   // Mark send buffer as busy
   m_send_pending = true;
@@ -750,14 +750,14 @@ void BoundaryExchange::recv_and_unpack_min_max ()
 
     if ( ! m_recv_requests.empty())
       HOMMEXX_MPI_CHECK_ERROR(MPI_Startall(m_recv_requests.size(), m_recv_requests.data()),
-                              m_connectivity->get_comm().m_mpi_comm);
+                              m_connectivity->get_comm().mpi_comm());
     m_recv_pending = true;
   }
 
   // ---- Recv ---- //
   if ( ! m_recv_requests.empty())
     HOMMEXX_MPI_CHECK_ERROR(MPI_Waitall(m_recv_requests.size(), m_recv_requests.data(), MPI_STATUSES_IGNORE),
-                            m_connectivity->get_comm().m_mpi_comm); // Wait for all data to arrive
+                            m_connectivity->get_comm().mpi_comm()); // Wait for all data to arrive
 
   m_buffers_manager->sync_recv_buffer(this); // Deep copy mpi_recv_buffer into recv_buffer (no op if MPI is on device)
 
@@ -840,7 +840,7 @@ void BoundaryExchange::recv_and_unpack_min_max ()
   // reusable.
   if ( ! m_send_requests.empty())
     HOMMEXX_MPI_CHECK_ERROR(MPI_Waitall(m_send_requests.size(), m_send_requests.data(), MPI_STATUSES_IGNORE),
-                            m_connectivity->get_comm().m_mpi_comm); // Wait for all data to arrive
+                            m_connectivity->get_comm().mpi_comm()); // Wait for all data to arrive
 
   // Release the send/recv buffers
   m_buffers_manager->unlock_buffers();
@@ -948,7 +948,7 @@ void BoundaryExchange::build_buffer_views_and_requests()
 
       for (int ifield=0; ifield<m_num_1d_fields; ++ifield) {
         h_send_1d_buffers(local.lid, ifield, local.pos) = ExecViewUnmanaged<Scalar[2][NUM_LEV]>(
-          reinterpret_cast<Scalar*>(send_buffer.get() + h_buf_offset[info.sharing]));  
+          reinterpret_cast<Scalar*>(send_buffer.get() + h_buf_offset[info.sharing]));
         h_recv_1d_buffers(local.lid, ifield, local.pos) = ExecViewUnmanaged<Scalar[2][NUM_LEV]>(
           reinterpret_cast<Scalar*>(recv_buffer.get() + h_buf_offset[info.sharing]));
         h_buf_offset[info.sharing] += h_increment_1d[info.kind]*NUM_LEV*VECTOR_SIZE;
@@ -998,7 +998,7 @@ void BoundaryExchange::build_buffer_views_and_requests()
 #endif // NDEBUG
 
   {
-    auto mpi_comm = m_connectivity->get_comm().m_mpi_comm;
+    auto mpi_comm = m_connectivity->get_comm().mpi_comm();
     const auto& connections = m_connectivity->get_connections<HostMemSpace>();
     const int npids = pids.size();
     free_requests();
@@ -1018,11 +1018,11 @@ void BoundaryExchange::build_buffer_views_and_requests()
       HOMMEXX_MPI_CHECK_ERROR(MPI_Send_init(send_ptr + offset, count, MPI_DOUBLE,
                                             pids[ip], m_exchange_type, mpi_comm,
                                             &m_send_requests[ip]),
-                              m_connectivity->get_comm().m_mpi_comm);
+                              m_connectivity->get_comm().mpi_comm());
       HOMMEXX_MPI_CHECK_ERROR(MPI_Recv_init(recv_ptr + offset, count, MPI_DOUBLE,
                                             pids[ip], m_exchange_type, mpi_comm,
                                             &m_recv_requests[ip]),
-                              m_connectivity->get_comm().m_mpi_comm);
+                              m_connectivity->get_comm().mpi_comm());
       offset += count;
     }
   }
@@ -1035,11 +1035,11 @@ void BoundaryExchange
 ::free_requests () {
   for (size_t i=0; i<m_send_requests.size(); ++i)
     HOMMEXX_MPI_CHECK_ERROR(MPI_Request_free(&m_send_requests[i]),
-                            m_connectivity->get_comm().m_mpi_comm);
+                            m_connectivity->get_comm().mpi_comm());
   m_send_requests.clear();
   for (size_t i=0; i<m_recv_requests.size(); ++i)
     HOMMEXX_MPI_CHECK_ERROR(MPI_Request_free(&m_recv_requests[i]),
-                            m_connectivity->get_comm().m_mpi_comm);
+                            m_connectivity->get_comm().mpi_comm());
   m_recv_requests.clear();
 }
 
@@ -1149,10 +1149,10 @@ void BoundaryExchange::waitall()
 
   if ( ! m_send_requests.empty())
     HOMMEXX_MPI_CHECK_ERROR(MPI_Waitall(m_send_requests.size(), m_send_requests.data(), MPI_STATUSES_IGNORE),
-                            m_connectivity->get_comm().m_mpi_comm);
+                            m_connectivity->get_comm().mpi_comm());
   if ( ! m_recv_requests.empty())
     HOMMEXX_MPI_CHECK_ERROR(MPI_Waitall(m_recv_requests.size(), m_recv_requests.data(), MPI_STATUSES_IGNORE),
-                            m_connectivity->get_comm().m_mpi_comm);
+                            m_connectivity->get_comm().mpi_comm());
 
   m_buffers_manager->unlock_buffers();
 }

--- a/src/share/cxx/mpi/Comm.cpp
+++ b/src/share/cxx/mpi/Comm.cpp
@@ -6,28 +6,28 @@
 
 #include "Comm.hpp"
 
-#include <iostream>
-
+#include <assert.h>
 #include "Config.hpp"
-
-#ifdef CAM
-#error "Error! We have not yet implemented the interface with CAM.\n"
-#endif
 
 namespace Homme
 {
 
 Comm::Comm()
- : m_mpi_comm (MPI_COMM_NULL)
- , m_size     (0)
- , m_rank     (-1)
 {
-  // Nothing to be done here
+  check_mpi_inited();
+  reset_mpi_comm (MPI_COMM_SELF);
 }
 
 Comm::Comm(MPI_Comm mpi_comm)
- : m_mpi_comm (mpi_comm)
 {
+  check_mpi_inited();
+  reset_mpi_comm (mpi_comm);
+}
+
+void Comm::reset_mpi_comm (MPI_Comm new_mpi_comm)
+{
+  m_mpi_comm = new_mpi_comm;
+
   MPI_Comm_size(m_mpi_comm,&m_size);
   MPI_Comm_rank(m_mpi_comm,&m_rank);
 
@@ -36,35 +36,11 @@ Comm::Comm(MPI_Comm mpi_comm)
 #endif
 }
 
-void Comm::init ()
+void Comm::check_mpi_inited () const
 {
-  if (m_mpi_comm!=MPI_COMM_NULL) {
-    std::cerr << "Error! You cannot call 'init' if the Comm was constructed from a given MPI_Comm.\n";
-    MPI_Abort(m_mpi_comm,1);
-  }
   int flag;
   MPI_Initialized (&flag);
-  if (!flag)
-  {
-    // Note: if we move main to C, consider initializing passing &argc/&argv
-    //       (the effect on the program would be the same, except that
-    //        mpi-specific stuff is removed from argc/argv)
-    MPI_Init (nullptr, nullptr);
-  }
-
-  m_mpi_comm = MPI_COMM_WORLD;
-
-  MPI_Comm_size(m_mpi_comm,&m_size);
-  MPI_Comm_rank(m_mpi_comm,&m_rank);
-
-#ifndef NDEBUG
-  MPI_Comm_set_errhandler(m_mpi_comm,MPI_ERRORS_RETURN);
-#endif
-}
-
-bool Comm::root () const
-{
-  return m_rank == 0;
+  assert (flag!=0);
 }
 
 } // namespace Homme

--- a/src/share/cxx/mpi/Comm.hpp
+++ b/src/share/cxx/mpi/Comm.hpp
@@ -18,23 +18,42 @@ namespace Homme
 //       but Teuchos does not support one-sided communication,
 //       which we *may* use in the future in the cxx code
 
-struct Comm
+// NOTE: this class checks that MPI is already init-ed, and errors out
+//       if it is not. It is YOUR responsibility to make sure MPI is
+//       init-ed before you create a Homme::Comm
+
+class Comm
 {
+public:
+
+  // The default comm creates a wrapper to MPI_COMM_SELF, rather than MPI_COMM_WORLD,
+  // because it is safer to assume I'm the only proc in the comm rather than assuming
+  // that the whole world is in my group.
+  Comm ();
+
+  // This constructor wraps the given MPI_Comm
+  Comm (MPI_Comm mpi_comm);
+
+  // This method resets the stored MPI_Comm to the given one,
+  // updating m_size and m_rank accordingly.
+  // WARNING: it is YOUR responsibility to ensure that
+  //   1) MPI is already inited (call check_mpi_init first, if you are not sure)
+  //   2) the call is collective on both the stored and input comm's
+  void reset_mpi_comm (MPI_Comm new_mpi_comm);
+
+  bool root () const { return m_rank==0; }
+  int  rank () const { return m_rank; }
+  int  size () const { return m_size; }
+  MPI_Comm mpi_comm () const { return m_mpi_comm; }
+
+private:
+  // Checks (with an assert) that MPI is already init-ed.
+  void check_mpi_inited () const;
+
   MPI_Comm  m_mpi_comm;
 
   int       m_size;
   int       m_rank;
-
-  Comm ();
-  Comm (MPI_Comm mpi_comm);
-
-  // So far this simply gets info from MPI_COMM_WORLD. But when
-  // Hommexx will be plugged back into acme, it will have to find
-  // out what processes are dedicated to Homme, and create a comm
-  // involving only those processes.
-  void init ();
-
-  bool root () const;
 };
 
 } // namespace Homme

--- a/src/share/cxx/mpi/Connectivity.cpp
+++ b/src/share/cxx/mpi/Connectivity.cpp
@@ -23,7 +23,7 @@ Connectivity::Connectivity ()
 void Connectivity::set_comm (const Comm& comm)
 {
   // Input comm must be valid (not storing a null MPI comm)
-  assert (comm.m_mpi_comm!=MPI_COMM_NULL);
+  assert (comm.mpi_comm()!=MPI_COMM_NULL);
 
   m_comm = comm;
 }
@@ -82,11 +82,11 @@ void Connectivity::add_connection (const int first_elem_lid,  const int first_el
   assert (!m_finalized);
 
   // Comm must not be a null comm, otherwise checks on ranks may be misleading
-  assert (m_comm.m_mpi_comm!=MPI_COMM_NULL);
+  assert (m_comm.mpi_comm()!=MPI_COMM_NULL);
 
   // I believe edges appear twice in fortran, once per each ordering.
   // Here, we only need to store them once
-  if (first_elem_pid==m_comm.m_rank)
+  if (first_elem_pid==m_comm.rank())
   {
 #ifndef NDEBUG
     // There is no edge-to-corner connection. Either the elements share a corner or an edge.
@@ -114,7 +114,7 @@ void Connectivity::add_connection (const int first_elem_lid,  const int first_el
     // Direction
     info.direction = etoi(m_helpers.CONNECTION_DIRECTION[local.pos][remote.pos]);
 
-    if (second_elem_pid!=m_comm.m_rank)
+    if (second_elem_pid!=m_comm.rank())
     {
       info.sharing = etoi(ConnectionSharing::SHARED);
       info.remote_pid = second_elem_pid;

--- a/src/share/cxx/mpi/mpi_cxx_f90_interface.cpp
+++ b/src/share/cxx/mpi/mpi_cxx_f90_interface.cpp
@@ -16,6 +16,11 @@ namespace Homme
 extern "C"
 {
 
+void init_cxx_mpi (const int& f_comm)
+{
+  Context::singleton().create_comm(f_comm);
+}
+
 void init_connectivity (const int& num_local_elems)
 {
   Connectivity& connectivity = *Context::singleton().get_connectivity();

--- a/src/share/cxx/mpi/mpi_cxx_f90_interface.cpp
+++ b/src/share/cxx/mpi/mpi_cxx_f90_interface.cpp
@@ -5,6 +5,7 @@
  *******************************************************************************/
 
 #include "Context.hpp"
+#include "Comm.hpp"
 #include "Connectivity.hpp"
 #include "BoundaryExchange.hpp"
 
@@ -18,7 +19,8 @@ extern "C"
 
 void init_cxx_mpi (const int& f_comm)
 {
-  Context::singleton().create_comm(f_comm);
+  MPI_Comm c_comm = MPI_Comm_f2c(f_comm);
+  Context::singleton().get_comm().reset_mpi_comm(c_comm);
 }
 
 void init_connectivity (const int& num_local_elems)

--- a/src/share/cxx/mpi/mpi_cxx_f90_interface.cpp
+++ b/src/share/cxx/mpi/mpi_cxx_f90_interface.cpp
@@ -60,10 +60,6 @@ void finalize_connectivity ()
   connectivity.finalize();
 }
 
-void cleanup_mpi_structures ()
-{
-}
-
 } // extern "C"
 
 } // namespace Homme

--- a/src/share/cxx/mpi/mpi_cxx_f90_interface.cpp
+++ b/src/share/cxx/mpi/mpi_cxx_f90_interface.cpp
@@ -17,8 +17,9 @@ namespace Homme
 extern "C"
 {
 
-void init_cxx_mpi (const int& f_comm)
+void reset_cxx_comm (const int& f_comm)
 {
+  // f_comm must be a valid Fortran handle to a communicator
   MPI_Comm c_comm = MPI_Comm_f2c(f_comm);
   Context::singleton().get_comm().reset_mpi_comm(c_comm);
 }

--- a/src/share/prim_cxx_driver_mod.F90
+++ b/src/share/prim_cxx_driver_mod.F90
@@ -8,17 +8,25 @@ module prim_cxx_driver_mod
 
   implicit none
 
-  public :: init_cxx_mpi_structures
+  public :: init_cxx_mpi_comm
+  public :: init_cxx_connectivity
   public :: cleanup_cxx_structures
 
   private :: generate_global_to_local
-  private :: init_c_connectivity
+  private :: init_cxx_connectivity_internal
 
 #include <mpif.h>
 
 contains
 
-  subroutine init_cxx_mpi_structures (nelemd, GridEdge, MetaVertex, par)
+  subroutine init_cxx_mpi_comm (f_comm) bind(c)
+    !
+    ! Inputs
+    !
+    integer(kind=c_int), intent(in) :: f_comm
+  end subroutine init_cxx_mpi_comm
+
+  subroutine init_cxx_connectivity (nelemd, GridEdge, MetaVertex, par)
     use dimensions_mod, only : nelem
     use gridgraph_mod,  only : GridEdge_t
     use metagraph_mod,  only : MetaVertex_t
@@ -37,9 +45,9 @@ contains
 
     call generate_global_to_local(MetaVertex,Global2Local,par)
 
-    call init_c_connectivity (nelemd, Global2Local, Gridedge)
+    call init_cxx_connectivity_internal (nelemd, Global2Local, Gridedge)
 
-  end subroutine init_cxx_mpi_structures
+  end subroutine init_cxx_connectivity
 
   subroutine cleanup_cxx_structures ()
     !
@@ -78,7 +86,7 @@ contains
 
   end subroutine generate_global_to_local
 
-  subroutine init_c_connectivity (nelemd,Global2Local,GridEdge)
+  subroutine init_cxx_connectivity_internal (nelemd,Global2Local,GridEdge)
     use gridgraph_mod,  only : GridEdge_t
     use dimensions_mod, only : nelem
     !
@@ -128,6 +136,6 @@ contains
     enddo
 
     call finalize_connectivity()
-  end subroutine init_c_connectivity
+  end subroutine init_cxx_connectivity_internal
 
 end module prim_cxx_driver_mod

--- a/src/share/prim_cxx_driver_mod.F90
+++ b/src/share/prim_cxx_driver_mod.F90
@@ -10,7 +10,6 @@ module prim_cxx_driver_mod
 
   public :: init_cxx_mpi_comm
   public :: init_cxx_connectivity
-  public :: cleanup_cxx_structures
 
   private :: generate_global_to_local
   private :: init_cxx_connectivity_internal
@@ -48,18 +47,6 @@ contains
     call init_cxx_connectivity_internal (nelemd, Global2Local, Gridedge)
 
   end subroutine init_cxx_connectivity
-
-  subroutine cleanup_cxx_structures ()
-    !
-    ! Interfaces
-    !
-    interface
-      subroutine cleanup_mpi_structures () bind(c)
-      end subroutine cleanup_mpi_structures
-    end interface
-
-    call cleanup_mpi_structures()
-  end subroutine cleanup_cxx_structures
 
   subroutine generate_global_to_local (MetaVertex, Global2Local, par)
     use dimensions_mod, only : nelem

--- a/src/share/prim_cxx_driver_mod.F90
+++ b/src/share/prim_cxx_driver_mod.F90
@@ -18,11 +18,26 @@ module prim_cxx_driver_mod
 
 contains
 
-  subroutine init_cxx_mpi_comm (f_comm) bind(c)
+  subroutine init_cxx_mpi_comm (f_comm)
+    use iso_c_binding, only: c_int
+    !
+    ! Interfaces
+    !
+    interface
+      subroutine reset_cxx_comm (f_comm) bind(c)
+        use iso_c_binding, only: c_int
+        !
+        ! Inputs
+        !
+        integer(kind=c_int), intent(in) :: f_comm
+      end subroutine reset_cxx_comm
+    end interface
     !
     ! Inputs
     !
-    integer(kind=c_int), intent(in) :: f_comm
+    integer, intent(in) :: f_comm
+
+    call reset_cxx_comm (INT(f_comm,c_int))
   end subroutine init_cxx_mpi_comm
 
   subroutine init_cxx_connectivity (nelemd, GridEdge, MetaVertex, par)

--- a/src/share/prim_driver_mod.F90
+++ b/src/share/prim_driver_mod.F90
@@ -124,7 +124,7 @@ contains
 #endif
 
 #ifdef USE_KOKKOS_KERNELS
-    use prim_cxx_driver_mod, only: init_cxx_mpi_structures
+    use prim_cxx_driver_mod, only: init_cxx_connectivity
 #endif
 
 #ifdef TRILINOS
@@ -323,7 +323,7 @@ contains
     call genEdgeSched(elem,iam,Schedule(1),MetaVertex(1))
 
 #ifdef USE_KOKKOS_KERNELS
-    call init_cxx_mpi_structures (nelemd, GridEdge, MetaVertex(1), par)
+    call init_cxx_connectivity (nelemd, GridEdge, MetaVertex(1), par)
 #endif
 
     allocate(global_shared_buf(nelemd,nrepro_vars))

--- a/test/unit_tests/tester.cpp
+++ b/test/unit_tests/tester.cpp
@@ -6,6 +6,9 @@
 #include <Kokkos_Core.hpp>
 
 #include "Hommexx_Session.hpp"
+#include "Context.hpp"
+#include "Comm.hpp"
+
 #include <mpi.h>
 
 int main(int argc, char **argv) {
@@ -14,6 +17,7 @@ int main(int argc, char **argv) {
   MPI_Init(&argc,&argv);
 
   Homme::initialize_hommexx_session();
+  Homme::Context::singleton().get_comm().reset_mpi_comm(MPI_COMM_WORLD);
 
   int result = Catch::Session().run(argc, argv);
 

--- a/test_execs/share_ut/boundary_exchange_ut.cpp
+++ b/test_execs/share_ut/boundary_exchange_ut.cpp
@@ -68,7 +68,7 @@ TEST_CASE ("Boundary Exchange", "Testing the boundary exchange framework")
 
   // Retrieve local number of elements
   int num_elements = connectivity->get_num_local_elements();
-  int rank = connectivity->get_comm().m_rank;
+  int rank = connectivity->get_comm().rank();
 
   // Create input data arrays
   HostViewManaged<Real*[num_min_max_fields_1d][2][NUM_PHYSICAL_LEV]> field_1d_f90("", num_elements);


### PR DESCRIPTION
This PR addresses issue #338, allowing Hommexx to use a communicator previously created in Fortran (e.g., by CAM).