### PR TITLE
Fix #348.

### DIFF
--- a/src/prim_main.F90
+++ b/src/prim_main.F90
@@ -344,20 +344,21 @@ program prim_main
           tl%nm1   = nm1_c + 1
           tl%n0    = n0_c  + 1
           tl%np1   = np1_c + 1
-          if (MODULO(tl%nstep,statefreq)==0 .or. tl%nstep >= nstep) then
-            call cxx_push_results_to_f90(elem_state_v_ptr, elem_state_temp_ptr, elem_state_dp3d_ptr, &
-                                         elem_state_Qdp_ptr, elem_state_Q_ptr, elem_state_ps_v_ptr,                    &
-                                         elem_derived_omega_p_ptr)
-          endif
 #else
           call prim_run_subcycle(elem, hybrid,nets,nete, tstep, tl, hvcoord,1)
 #endif
-          if(.not. disable_diagnostics) then
-            if (MODULO(tl%nstep,statefreq)==0 .or. tl%nstep >= nEndStep) then
-              call prim_printstate(elem,tl,hybrid,hvcoord,nets,nete)
-            endif
-          endif
-        else  ! leapfrog
+#ifdef USE_KOKKOS_KERNELS
+          if (MODULO(tl%nstep,statefreq)==0 .or. tl%nstep >= nstep) then
+            call cxx_push_results_to_f90(elem_state_v_ptr, elem_state_temp_ptr, elem_state_dp3d_ptr, &
+                                         elem_state_Qdp_ptr, elem_state_Q_ptr, elem_state_ps_v_ptr, &
+                                         elem_derived_omega_p_ptr)
+         endif
+#endif
+         if (.not. disable_diagnostics .and. &
+              (MODULO(tl%nstep, statefreq) == 0 .or. tl%nstep >= nEndStep)) then
+            call prim_printstate(elem,tl,hybrid,hvcoord,nets,nete)
+         endif
+      else  ! leapfrog
 #ifdef USE_KOKKOS_KERNELS
            call abortmp ("Error! Functionality not available in Kokkos build")
 #else

--- a/src/share/cxx/Diagnostics.cpp
+++ b/src/share/cxx/Diagnostics.cpp
@@ -8,6 +8,7 @@
 #include "TimeLevel.hpp"
 #include "Tracers.hpp"
 
+#include "utilities/SyncUtils.hpp"
 #include "utilities/SubviewUtils.hpp"
 
 namespace Homme
@@ -55,6 +56,10 @@ void Diagnostics::prim_diag_scalars (const bool before_advance, const int ivar)
 
   if (params.time_step_type>0) {
     const Tracers& tracers = Context::singleton().get_tracers();
+
+    sync_to_host(tracers.Q,
+                 HostViewUnmanaged<Real*[QSIZE_D][NUM_PHYSICAL_LEV][NP][NP]>(
+                   h_Q.data(), m_num_elems));
 
     // Copy back tracers concentration and mass
     auto qdp_h = Kokkos::create_mirror_view(tracers.qdp);

--- a/src/share/cxx/cxx_f90_interface.cpp
+++ b/src/share/cxx/cxx_f90_interface.cpp
@@ -120,6 +120,7 @@ void cxx_push_results_to_f90(F90Ptr& elem_state_v_ptr,   F90Ptr& elem_state_temp
   Kokkos::deep_copy(ps_v_f90,ps_v_host);
 
   sync_to_host(elements.m_omega_p,HostViewUnmanaged<Real *[NUM_PHYSICAL_LEV][NP][NP]>(elem_derived_omega_p_ptr,elements.num_elems()));
+  sync_to_host(tracers.Q,HostViewUnmanaged<Real*[QSIZE_D][NUM_PHYSICAL_LEV][NP][NP]>(elem_Q_ptr,elements.num_elems()));
 }
 
 void init_derivative_c (CF90Ptr& dvv)

--- a/src/share/cxx/prim_driver.cpp
+++ b/src/share/cxx/prim_driver.cpp
@@ -207,28 +207,6 @@ void update_q (const int np1_qdp, const int np1)
     const Scalar dp = hyai_delta(level)*ps0 + hybi_delta(level)*ps_v(ie,np1,igp,jgp);
     Q(ie,iq,igp,jgp,level) = qdp(ie,np1_qdp,iq,igp,jgp,level)/dp;
   });
-
-  // Get the tracers concentration from Diagnostics
-  Diagnostics& diags = Context::singleton().get_diagnostics();
-  auto h_Q = diags.h_Q;
-
-  // Update the host copy of Q, stored in Diagnostics
-  ExecViewManaged<Scalar*[QSIZE_D][NP][NP][NUM_LEV]>::HostMirror Q_host;
-  Q_host = Kokkos::create_mirror_view(Q);
-  Kokkos::deep_copy(Q_host,Q);
-
-  Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,num_elems*qsize*NP*NP*NUM_PHYSICAL_LEV),
-                       KOKKOS_LAMBDA(const int idx) {
-    const int ie    =  idx / (qsize*NP*NP*NUM_PHYSICAL_LEV);
-    const int iq    = (idx / (NP*NP*NUM_PHYSICAL_LEV)) % qsize;
-    const int igp   = (idx / (NP*NUM_PHYSICAL_LEV)) % NP;
-    const int jgp   = (idx / NUM_PHYSICAL_LEV) % NP;
-    const int level =  idx % NUM_PHYSICAL_LEV;
-    const int ilev = level / VECTOR_SIZE;
-    const int ivec = level % VECTOR_SIZE;
-
-    h_Q(ie,iq,level,igp,jgp) = Q_host(ie,iq,igp,jgp,ilev)[ivec];
-  });
 }
 
 } // namespace Homme


### PR DESCRIPTION
update_q was deep_copy'ing Q at every remap step. It should only be done when at
least one of I/O and diagnostics is requested. This commit fixes that.