### PR TITLE
Fix #342

### DIFF
--- a/dashboards/bowman.sandia.gov/build_kokkos.sh
+++ b/dashboards/bowman.sandia.gov/build_kokkos.sh
@@ -6,7 +6,7 @@ mkdir KokkosBuild
 cd KokkosBuild
 
 jenkins_trilinos_dir=/home/projects/hommexx/nightlyCDash/repos/Trilinos
-${jenkins_trilinos_dir}/packages/kokkos/generate_makefile.bash --with-openmp --with-serial --compiler=icpc --with-options=aggressive_vectorization,disable_profiling --prefix=/home/projects/hommexx/nightlyCDash/build/KokkosInstall --arch=KNL --cxxflags="-O3"
+${jenkins_trilinos_dir}/packages/kokkos/generate_makefile.bash --with-openmp --with-serial --compiler=icpc --with-options=aggressive_vectorization,disable_profiling,disable_deprecated_code --prefix=/home/projects/hommexx/nightlyCDash/build/KokkosInstall --arch=KNL --cxxflags="-O3"
 make -j 24
 make install -j 24
 

--- a/dashboards/ride.sandia.gov/build_kokkos.sh
+++ b/dashboards/ride.sandia.gov/build_kokkos.sh
@@ -7,6 +7,6 @@ cd build
 mkdir KokkosBuild
 cd KokkosBuild
 sed -e s/default_arch=\"sm_35\"/default_arch=\"sm_60\"/ -e s/cuda_args=\"\"/cuda_args=\"--fmad=false\"/ nvcc_wrapper -i ${jenkins_trilinos_dir}/packages/kokkos/bin/nvcc_wrapper 
-${jenkins_trilinos_dir}/packages/kokkos/generate_makefile.bash --compiler=${jenkins_trilinos_dir}/packages/kokkos/bin/nvcc_wrapper --prefix=/home/projects/hommexx/nightlyCDash/build/KokkosInstall --with-serial --with-cuda=${CUDA_ROOT} --with-cuda-options=enable_lambda --with-options=aggressive_vectorization --arch=Pascal60
+${jenkins_trilinos_dir}/packages/kokkos/generate_makefile.bash --compiler=${jenkins_trilinos_dir}/packages/kokkos/bin/nvcc_wrapper --prefix=/home/projects/hommexx/nightlyCDash/build/KokkosInstall --with-serial --with-cuda=${CUDA_ROOT} --with-cuda-options=enable_lambda --with-options=disable_deprecated_code --with-options=aggressive_vectorization --arch=Pascal60
 make -j 24
 make install -j 24 

--- a/dashboards/ride.sandia.gov/build_kokkos.sh
+++ b/dashboards/ride.sandia.gov/build_kokkos.sh
@@ -7,6 +7,6 @@ cd build
 mkdir KokkosBuild
 cd KokkosBuild
 sed -e s/default_arch=\"sm_35\"/default_arch=\"sm_60\"/ -e s/cuda_args=\"\"/cuda_args=\"--fmad=false\"/ nvcc_wrapper -i ${jenkins_trilinos_dir}/packages/kokkos/bin/nvcc_wrapper 
-${jenkins_trilinos_dir}/packages/kokkos/generate_makefile.bash --compiler=${jenkins_trilinos_dir}/packages/kokkos/bin/nvcc_wrapper --prefix=/home/projects/hommexx/nightlyCDash/build/KokkosInstall --with-serial --with-cuda=${CUDA_ROOT} --with-cuda-options=enable_lambda --with-options=disable_deprecated_code --with-options=aggressive_vectorization --arch=Pascal60
+${jenkins_trilinos_dir}/packages/kokkos/generate_makefile.bash --compiler=${jenkins_trilinos_dir}/packages/kokkos/bin/nvcc_wrapper --prefix=/home/projects/hommexx/nightlyCDash/build/KokkosInstall --with-serial --with-cuda=${CUDA_ROOT} --with-cuda-options=enable_lambda --with-options=disable_deprecated_code,aggressive_vectorization --arch=Pascal60
 make -j 24
 make install -j 24 

--- a/src/preqx/unit_tests/preqx_ut.cpp
+++ b/src/preqx/unit_tests/preqx_ut.cpp
@@ -105,7 +105,7 @@ public:
             Context::singleton().get_hvcoord(),
             SphereOperators(elements, Context::singleton().get_derivative()),
             rsplit_in),
-        policy(functor.m_elements.num_elems(), 16, 4),
+        policy(Homme::get_default_team_policy<ExecSpace>(elements.num_elems())),
         velocity("Velocity", elements.num_elems()),
         temperature("Temperature", elements.num_elems()),
         dp3d("DP3D", elements.num_elems()),
@@ -159,7 +159,7 @@ public:
   }
 
   CaarFunctorImpl functor;
-  Kokkos::TeamPolicy<ExecSpace> policy;
+  Kokkos::TeamPolicy<ExecSpace,void> policy;
 
   // host
   // Arrays used to pass data to and from Fortran

--- a/src/preqx/unit_tests/preqx_ut.cpp
+++ b/src/preqx/unit_tests/preqx_ut.cpp
@@ -1202,7 +1202,7 @@ TEST_CASE("preq_vertadv", "monolithic compute_and_apply_rhs") {
   HostViewManaged<Real * [NUM_INTERFACE_LEV][NP][NP]> eta_dot_f90("eta_dot f90", num_elems);
   HostViewManaged<Real * [NUM_PHYSICAL_LEV][NP][NP]> t_vadv_f90("tavd f90", num_elems);
   HostViewManaged<Real * [NUM_PHYSICAL_LEV][2][NP][NP]> v_vadv_f90("vavd f90", num_elems);
-  HostViewManaged<Real [NUM_PHYSICAL_LEV][NP][NP]> rdp_f90("rdp f90", num_elems);
+  HostViewManaged<Real [NUM_PHYSICAL_LEV][NP][NP]> rdp_f90("rdp f90");
 
   deep_copy(eta_dot_f90, eta_dot);
   deep_copy(t_vadv_f90, t_vadv);

--- a/src/preqx/unit_tests/preqx_ut_remap.cpp
+++ b/src/preqx/unit_tests/preqx_ut_remap.cpp
@@ -128,7 +128,7 @@ public:
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const TagGridTest &, TeamMember team) const {
+  void operator()(const TagGridTest &, const TeamMember& team) const {
     KernelVariables kv(team);
     Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team, NP * NP),
                          [&](const int &loop_idx) {
@@ -216,7 +216,7 @@ public:
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const TagPPMTest &, TeamMember team) const {
+  void operator()(const TagPPMTest &, const TeamMember& team) const {
     KernelVariables kv(team);
     Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team, num_remap * NP * NP),
                          [&](const int &loop_idx) {
@@ -366,7 +366,7 @@ public:
   }
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(const TagRemapTest &, TeamMember team) const {
+  void operator()(const TagRemapTest &, const TeamMember& team) const {
     KernelVariables kv(team);
     remap.compute_grids_phase(
         kv, Homme::subview(src_layer_thickness_kokkos, kv.ie),

--- a/src/preqx/unit_tests/preqx_ut_sphere_op_ml.cpp
+++ b/src/preqx/unit_tests/preqx_ut_sphere_op_ml.cpp
@@ -346,13 +346,13 @@ class compute_sphere_operator_test_ml {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TagDefault &,
-                  TeamMember team) const {
+                  const TeamMember& team) const {
       // do nothing or print a message
   };
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TagGradientSphereML &,
-                  TeamMember team) const {
+                  const TeamMember& team) const {
     KernelVariables kv(team);
 
     sphere_ops.gradient_sphere(team,
@@ -363,7 +363,7 @@ class compute_sphere_operator_test_ml {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TagDivergenceSphereWkML &,
-                  TeamMember team) const {
+                  const TeamMember& team) const {
     KernelVariables kv(team);
 
     sphere_ops.divergence_sphere_wk(team,
@@ -373,7 +373,7 @@ class compute_sphere_operator_test_ml {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TagSimpleLaplaceML &,
-                  TeamMember team) const {
+                  const TeamMember& team) const {
     KernelVariables kv(team);
 
     sphere_ops.laplace_simple(team,
@@ -383,7 +383,7 @@ class compute_sphere_operator_test_ml {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TagTensorLaplaceML &,
-                  TeamMember team) const {
+                  const TeamMember& team) const {
     KernelVariables kv(team);
 
     sphere_ops.laplace_tensor(team,
@@ -394,7 +394,7 @@ class compute_sphere_operator_test_ml {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TagCurlSphereWkTestCovML &,
-                  TeamMember team) const {
+                  const TeamMember& team) const {
     KernelVariables kv(team);
 
     sphere_ops.curl_sphere_wk_testcov(team,
@@ -404,7 +404,7 @@ class compute_sphere_operator_test_ml {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TagGradSphereWkTestCovML &,
-                  TeamMember team) const {
+                  const TeamMember& team) const {
     KernelVariables kv(team);
 
     sphere_ops.grad_sphere_wk_testcov(team,
@@ -414,7 +414,7 @@ class compute_sphere_operator_test_ml {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TagVLaplaceCartesianML &,
-                  TeamMember team) const {
+                  const TeamMember& team) const {
     KernelVariables kv(team);
 
     sphere_ops.vlaplace_sphere_wk_cartesian (team,
@@ -426,7 +426,7 @@ class compute_sphere_operator_test_ml {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TagVLaplaceContraML &,
-                  TeamMember team) const {
+                  const TeamMember& team) const {
     KernelVariables kv(team);
 
     // don't forget to introduce nu_ratio
@@ -438,7 +438,7 @@ class compute_sphere_operator_test_ml {
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TagVorticityVectorML &,
-                  TeamMember team) const {
+                  const TeamMember& team) const {
     KernelVariables kv(team);
     sphere_ops.vorticity_sphere (team,
                       Homme::subview(vector_input_d, kv.ie),

--- a/src/preqx/unit_tests/preqx_ut_sphere_op_sl.cpp
+++ b/src/preqx/unit_tests/preqx_ut_sphere_op_sl.cpp
@@ -237,9 +237,7 @@ class compute_sphere_operator_test {
   // put in a param in run_functor(param) to only branch
   // policy type
   void run_functor_simple_laplace() {
-    // league, team, vector_length_request=1
-    Kokkos::TeamPolicy<ExecSpace, TagSimpleLaplace> policy(
-        _num_elems, 16);
+    auto policy = Homme::get_default_team_policy<ExecSpace,TagSimpleLaplace>(_num_elems);
     sphere_ops.allocate_buffers(policy);
     Kokkos::parallel_for(policy, *this);
     ExecSpace::fence();
@@ -248,9 +246,7 @@ class compute_sphere_operator_test {
   };
 
   void run_functor_gradient_sphere() {
-    // league, team, vector_length_request=1
-    Kokkos::TeamPolicy<ExecSpace, TagGradientSphere> policy(
-        _num_elems, 16);
+    auto policy = Homme::get_default_team_policy<ExecSpace,TagGradientSphere>(_num_elems);
     sphere_ops.allocate_buffers(policy);
     Kokkos::parallel_for(policy, *this);
     ExecSpace::fence();
@@ -259,9 +255,7 @@ class compute_sphere_operator_test {
   };
 
   void run_functor_div_wk() {
-    // league, team, vector_length_request=1
-    Kokkos::TeamPolicy<ExecSpace, TagDivergenceSphereWk>
-        policy(_num_elems, 16);
+    auto policy = Homme::get_default_team_policy<ExecSpace,TagDivergenceSphereWk>(_num_elems);
     sphere_ops.allocate_buffers(policy);
     Kokkos::parallel_for(policy, *this);
     ExecSpace::fence();

--- a/src/share/cxx/ExecSpaceDefs.hpp
+++ b/src/share/cxx/ExecSpaceDefs.hpp
@@ -133,7 +133,12 @@ struct DefaultThreadsDistribution {
   team_num_threads_vectors(const int num_parallel_iterations,
                            const ThreadPreferences tp = ThreadPreferences()) {
     return Parallel::team_num_threads_vectors_from_pool(
-      ExecSpaceType::thread_pool_size(), num_parallel_iterations, tp);
+#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
+      ExecSpaceType::thread_pool_size()
+#else
+      ExecSpaceType::impl_thread_pool_size()
+#endif
+      , num_parallel_iterations, tp);
   }
 };
 

--- a/src/share/cxx/ExecSpaceDefs.hpp
+++ b/src/share/cxx/ExecSpaceDefs.hpp
@@ -328,7 +328,7 @@ struct Dispatch<Kokkos::Cuda> {
     // Broadcast result to all threads by doing sum of one thread's
     // non-0 value and the rest of the 0s.
     Kokkos::Impl::CudaTeamMember::vector_reduce(
-      Kokkos::Experimental::Sum<ValueType>(result));
+      Kokkos::Sum<ValueType>(result));
 #else
     Kokkos::parallel_reduce(loop_boundaries, lambda, result);
 #endif

--- a/src/share/cxx/mpi/BoundaryExchange.cpp
+++ b/src/share/cxx/mpi/BoundaryExchange.cpp
@@ -158,8 +158,8 @@ void BoundaryExchange::clean_up()
   assert (!m_send_pending && !m_recv_pending);
 
   // Clear stored fields
-  m_2d_fields = decltype(m_2d_fields)(0, 0);
-  m_3d_fields = decltype(m_3d_fields)(0, 0);
+  m_2d_fields = decltype(m_2d_fields)("m_2d_fields", 0, 0);
+  m_3d_fields = decltype(m_3d_fields)("m_3d_fields", 0, 0);
 
   m_num_2d_fields = 0;
   m_num_3d_fields = 0;
@@ -1124,12 +1124,12 @@ void BoundaryExchange::clear_buffer_views_and_requests ()
   free_requests();
 
   // Clear buffer views
-  m_send_1d_buffers = decltype(m_send_1d_buffers)(0, 0);
-  m_recv_1d_buffers = decltype(m_recv_1d_buffers)(0, 0);
-  m_send_2d_buffers = decltype(m_send_2d_buffers)(0, 0);
-  m_recv_2d_buffers = decltype(m_recv_2d_buffers)(0, 0);
-  m_send_3d_buffers = decltype(m_send_3d_buffers)(0, 0);
-  m_recv_3d_buffers = decltype(m_recv_3d_buffers)(0, 0);
+  m_send_1d_buffers = decltype(m_send_1d_buffers)("m_send_1d_buffers", 0, 0);
+  m_recv_1d_buffers = decltype(m_recv_1d_buffers)("m_recv_1d_buffers", 0, 0);
+  m_send_2d_buffers = decltype(m_send_2d_buffers)("m_send_2d_buffers", 0, 0);
+  m_recv_2d_buffers = decltype(m_recv_2d_buffers)("m_recv_2d_buffers", 0, 0);
+  m_send_3d_buffers = decltype(m_send_3d_buffers)("m_send_3d_buffers", 0, 0);
+  m_recv_3d_buffers = decltype(m_recv_3d_buffers)("m_recv_3d_buffers", 0, 0);
 
   // Done
   m_buffer_views_and_requests_built = false;

--- a/src/share/cxx/utilities/SubviewUtils.hpp
+++ b/src/share/cxx/utilities/SubviewUtils.hpp
@@ -260,6 +260,19 @@ subview(ViewType<ScalarType * [DIM1][DIM2][DIM3][DIM4][DIM5], MemSpace,
 
 template <typename ScalarType, int DIM1, int DIM2, int DIM3,
           typename MemSpace, typename... Properties>
+KOKKOS_INLINE_FUNCTION ViewUnmanaged<ScalarType * [DIM1][DIM2][DIM3], MemSpace>
+subview(ViewType<ScalarType ** [DIM1][DIM2][DIM3], MemSpace,
+                 Properties...> v_in,
+        int ie) {
+  assert(v_in.data() != nullptr);
+  assert(ie < v_in.extent_int(0));
+  assert(ie >= 0);
+  return ViewUnmanaged<ScalarType * [DIM1][DIM2][DIM3], MemSpace>(
+    &v_in.implementation_map().reference(ie, 0, 0, 0, 0), v_in.extent_int(1));
+}
+
+template <typename ScalarType, int DIM1, int DIM2, int DIM3,
+          typename MemSpace, typename... Properties>
 KOKKOS_INLINE_FUNCTION ViewUnmanaged<ScalarType[DIM1][DIM2][DIM3], MemSpace>
 subview(ViewType<ScalarType ** [DIM1][DIM2][DIM3], MemSpace,
                  Properties...> v_in,

--- a/test_execs/share_ut/infrastructure_ut.cpp
+++ b/test_execs/share_ut/infrastructure_ut.cpp
@@ -118,7 +118,7 @@ TEST_CASE("ExecSpaceDefs",
 
 template <typename Dispatcher, int num_points, int scan_length>
 void test_parallel_scan(
-    Kokkos::TeamPolicy<ExecSpace> policy,
+    Kokkos::TeamPolicy<ExecSpace,void> policy,
     ExecViewManaged<const Real * [num_points][scan_length]> input,
     ExecViewManaged<Real * [num_points][scan_length]> output) {
   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const TeamMember & team) {
@@ -143,7 +143,7 @@ void test_parallel_scan(
 template <typename ExeSpace> struct KokkosDispatcher {
   template <class Lambda>
   static KOKKOS_FORCEINLINE_FUNCTION void
-  parallel_scan(const typename Kokkos::TeamPolicy<ExeSpace>::member_type &team,
+  parallel_scan(const typename Kokkos::TeamPolicy<ExeSpace,void>::member_type &team,
                 const int num_iters, const Lambda &lambda) {
     Kokkos::parallel_scan(Kokkos::ThreadVectorRange(team, num_iters), lambda);
   }
@@ -162,7 +162,7 @@ TEST_CASE("Parallel_scan",
                                                                   num_elems);
 
   // Policy used in all parallel for's below
-  Kokkos::TeamPolicy<ExecSpace> policy(num_elems,num_points,vector_length);
+  auto policy = Homme::get_default_team_policy<ExecSpace>(num_elems);
   policy.set_chunk_size(1);
 
   // Fill the input view.


### PR DESCRIPTION
Fix use of a deprecated namespace for a function. Requires current Kokkos master, Kokkos SHA1 d3a941.